### PR TITLE
add output option to css plugin and svelte plugin

### DIFF
--- a/packages/rollup-plugin-uniroll-css/src/index.ts
+++ b/packages/rollup-plugin-uniroll-css/src/index.ts
@@ -6,19 +6,19 @@ import { wrapWithStyleInjector } from "./wrapWithInjector";
 export const css = (options: Options = {}) => {
 
   const willOutputFile = !!options.output;
-  let cssFiles = Object.create(null);
+  let cssFiles: string[] = [];
 
   return {
     name: 'css',
     buildStart() {
-      cssFiles = {};
+      cssFiles = [];
     },
     async transform(code: string, id: string): Promise<string | void> {
       if (!id.endsWith('.css')) return;
       const css = await transformCss(code, options);
       
       if (willOutputFile) {
-        cssFiles[id] = css;
+        cssFiles.push(css);
         return;
       } else {
         return wrapWithStyleInjector(css);
@@ -30,7 +30,7 @@ export const css = (options: Options = {}) => {
       this.emitFile({
         type: "asset",
         fileName: options.output,
-        source: cssFiles.join("")
+        source: cssFiles.join(""),
       });
     }
   } as Plugin;

--- a/packages/rollup-plugin-uniroll-css/src/index.ts
+++ b/packages/rollup-plugin-uniroll-css/src/index.ts
@@ -9,7 +9,7 @@ export const css = (options: Options = {}) => {
   let cssFiles: string[] = [];
 
   return {
-    name: 'css',
+    name: 'uniroll-css',
     buildStart() {
       cssFiles = [];
     },

--- a/packages/rollup-plugin-uniroll-css/src/index.ts
+++ b/packages/rollup-plugin-uniroll-css/src/index.ts
@@ -4,12 +4,34 @@ import { transformCss } from "./transformCss";
 import { wrapWithStyleInjector } from "./wrapWithInjector";
 
 export const css = (options: Options = {}) => {
+
+  const willOutputFile = !!options.output;
+  let cssFiles = Object.create(null);
+
   return {
+    name: 'css',
+    buildStart() {
+      cssFiles = {};
+    },
     async transform(code: string, id: string): Promise<string | void> {
-      if (id.endsWith(".css")) {
-        const css = await transformCss(code, options);
+      if (!id.endsWith('.css')) return;
+      const css = await transformCss(code, options);
+      
+      if (willOutputFile) {
+        cssFiles[id] = css;
+        return;
+      } else {
         return wrapWithStyleInjector(css);
       }
+    },
+    generateBundle() {
+      if (!willOutputFile) return;
+      if (cssFiles.length === 0) return;
+      this.emitFile({
+        type: "asset",
+        fileName: options.output,
+        source: cssFiles.join("")
+      });
     }
   } as Plugin;
 };

--- a/packages/rollup-plugin-uniroll-css/src/types.ts
+++ b/packages/rollup-plugin-uniroll-css/src/types.ts
@@ -1,3 +1,7 @@
 export type Options = {
   postprocess?: (css: string) => Promise<string>;
+  /**
+   * output css file instead of js injection.
+   */
+  output?: string;
 };

--- a/packages/rollup-plugin-uniroll-svelte/README.md
+++ b/packages/rollup-plugin-uniroll-svelte/README.md
@@ -124,6 +124,43 @@ const rolled = await bundle({
 });
 ```
 
+## Output css instead of css injection code
+```ts
+import type { Plugin } from "rollup";
+import ts from "typescript";
+import { bundle } from "uniroll";
+import { svelte } from "rollup-plugin-uniroll-svelte";
+import { css } from 'rollup-plugin-uniroll-css';
+const files = {
+  /* ... */
+};
+const cdnPrefix = "https://cdn.skypack.dev/";
+const rolled = await bundle({
+  input: "/index.tsx",
+  files,
+  cdnPrefix,
+  compilerOptions: {
+    target: ts.ScriptTarget.ES5,
+  },
+  extraPlugins: [
+    svelte({
+      target: ts.ScriptTarget.ES5,
+      cdnPrefix,
+      svelteOptions: {
+        /**
+         * output css instead of js injection
+         */
+        css: false,
+      },
+    }),
+    /**
+     * bundle css files including css that svelte emitted
+     */
+    css({ output: 'bundle.css' });
+  ]
+});
+```
+
 ## LICENSE
 
 MIT


### PR DESCRIPTION
resolve https://github.com/mizchi/uniroll/issues/27 https://github.com/mizchi/uniroll/issues/28

- svelte: svelte.option.css が false だと、css を file として output するようにする
- css: opt.output が設定されてると、css を asset file として output するようにする

## 疑問
- local で test 動かせませんでした