### PR TITLE
Svelte warning

### DIFF
--- a/packages/rollup-plugin-uniroll-svelte/src/index.ts
+++ b/packages/rollup-plugin-uniroll-svelte/src/index.ts
@@ -42,9 +42,16 @@ export const svelte = ({
           }
         );
         const result = svelteCompile(preprocessed, svelteOptions);
-        if (result.warnings.length > 0) {
-          this.warn(result.warnings.map((t) => t.message).join("\n"));
-        }
+        result.warnings.forEach(warning => {
+          const start = warning.start;
+          if (start !== undefined) {
+            const line = start.line;
+            const column = start.column;
+            this.warn(warning.message + " (" + line + ":" + column + ")");
+          } else {
+            this.warn(warning.message);
+          }
+        });
 
         if (emitCss && result.css.code) {
           const hash = Math.random().toString(32).substring(2);

--- a/packages/rollup-plugin-uniroll-svelte/test/svelte-plugin.test.ts
+++ b/packages/rollup-plugin-uniroll-svelte/test/svelte-plugin.test.ts
@@ -3,7 +3,7 @@ import fetch from "isomorphic-unfetch";
 import { bundle } from "uniroll";
 import { svelte } from "../src";
 import ts from "typescript";
-import { Plugin } from "rollup";
+import { Plugin, RollupWarning } from "rollup";
 import { createStylePreprocessor } from "../src/server/stylePreprocessor";
 import { css } from "rollup-plugin-uniroll-css";
 global.fetch = fetch;
@@ -63,6 +63,47 @@ new App({target: document.body});
 
   const out = await bundled.generate({ format: "es" });
   expect(out.output[0].code).toMatchSnapshot();
+});
+
+it("bundle svelte warnings check", async () => {
+  let warnings: RollupWarning[] = [];
+  const bundled = await bundle({
+    // resolveIdFallback: "https://cdn.skypack.dev/",
+    resolveIdFallback,
+    input: "/index.tsx",
+    files: {
+      "/index.tsx": `
+import App from "./App.svelte";
+new App({target: document.body});
+      `,
+      "/App.svelte": `
+<script lang="ts">
+  let x = 1;
+</script>
+<style>
+  .text {
+    color: red;
+  }
+</style>
+<span class="text">{z}</span> // z is not defined 
+      `,
+    },
+    rollupOptions: {
+      onwarn(warn) {
+        warnings.push(warn);
+      },
+    },
+    extraPlugins: [
+      svelte({
+        target: ts.ScriptTarget.ES2019,
+        resolveIdFallback,
+        svelteOptions: {},
+      }) as any,
+    ],
+  });
+  console.log(warnings);
+  expect(warnings.length).toBe(1);
+  expect(warnings[0].message).toBe("'z' is not defined (9:20)");
 });
 
 it("bundle for es5", async () => {


### PR DESCRIPTION
rollup-plugin-uniroll-svelte

- warningsの際にどの部分が警告されているのか確認しやすいように行番号と列番号を表示するようにしました。

テストでの動作確認済み。


## メモ
snapshotと比較するテストが落ちていました。