### PR TITLE
Feature/version down

### DIFF
--- a/packages/rollup-plugin-uniroll-svelte/rollup.config.js
+++ b/packages/rollup-plugin-uniroll-svelte/rollup.config.js
@@ -45,7 +45,7 @@ export default [
       }),
       ts({
         tsconfig: {
-          target: tsService.ScriptTarget.ES2018,
+          target: tsService.ScriptTarget.ES2019,
           allowSyntheticDefaultImports: true,
           allowJs: true,
         },

--- a/packages/rollup-plugin-uniroll-svelte/rollup.config.js
+++ b/packages/rollup-plugin-uniroll-svelte/rollup.config.js
@@ -45,7 +45,7 @@ export default [
       }),
       ts({
         tsconfig: {
-          target: tsService.ScriptTarget.ES2019,
+          target: tsService.ScriptTarget.ES2018,
           allowSyntheticDefaultImports: true,
           allowJs: true,
         },

--- a/packages/rollup-plugin-uniroll-svelte/src/index.ts
+++ b/packages/rollup-plugin-uniroll-svelte/src/index.ts
@@ -33,7 +33,8 @@ export const svelte = ({
         const tsPreprocess = createSveltePreprocessor({
           target,
           importer: id,
-          resolveIdFallback: resolveIdFallback ?? defaultResolveIdFallback,
+          resolveIdFallback: 
+            (resolveIdFallback !== null && resolveIdFallback !== undefined) ? resolveIdFallback : defaultResolveIdFallback,
         });
         const { code: preprocessed } = await preprocess(
           code,

--- a/packages/rollup-plugin-uniroll-svelte/src/tsPreprocess.ts
+++ b/packages/rollup-plugin-uniroll-svelte/src/tsPreprocess.ts
@@ -13,7 +13,8 @@ export const createSveltePreprocessor = ({
 }) => {
   const script: Preprocessor = async ({ content, attributes, filename }) => {
     const out = transpileSvelteTypeScript(content, {
-      fileName: filename ?? "/$$.tsx",
+      // fileName: filename ?? "/$$.tsx",
+      fileName: (filename !== null && filename !== undefined) ? filename : 'default string',
       resolveIdFallback,
       importer,
       target,
@@ -91,8 +92,11 @@ export const cdnRewriteTransformerFactory = (
 ) => (ctx: ts.TransformationContext) => {
   function visitNode(node: ts.Node): ts.Node {
     if (ts.isImportDeclaration(node)) {
-      if (node.importClause?.isTypeOnly) {
-        return ts.factory.createEmptyStatement();
+      // if (node.importClause?.isTypeOnly) {
+      //   return ts.factory.createEmptyStatement();
+      // }
+      if (node.importClause !== undefined && node.importClause.isTypeOnly) {
+          return ts.factory.createEmptyStatement();
       }
 
       const specifier = node.moduleSpecifier.getText();


### PR DESCRIPTION
#37 

Module parse failed: Unexpected tokenとして弾かれてしまうので
rollup-plugin-uniroll-svelteのES2020の文法を使用している三箇所を修正しました。


#### 参考文献
https://ics.media/entry/200128/